### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Table of Contents
 * [Go library](https://github.com/paked/messenger)
  
 ### Slack
-* [node.js (Official)](https://github.com/slackhq/node-slack-client)
+* [node.js (Official)](https://github.com/slackhq/node-slack-sdk)
 * [Python (Official)](https://github.com/slackhq/python-slackclient)
 
 ### Telegram


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein
### GitHub Corrected URLs

| Was | Now |
| --- | --- |
| https://github.com/slackhq/node-slack-client | https://github.com/slackhq/node-slack-sdk |
