### PR TITLE
Add PHP Telegram Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Table of Contents
 * [Node.js](https://github.com/telegraf/telegraf)
 * [Node.js](https://github.com/Yoctol/messaging-apis/tree/master/packages/messaging-api-telegram)
 * [PHP](https://github.com/irazasyed/telegram-bot-sdk)
+* [PHP](https://github.com/php-telegram-bot/core)
 * [Python](https://github.com/python-telegram-bot/python-telegram-bot)
 * [C#](https://github.com/MrRoundRobin/telegram.bot)
 * [Go](https://github.com/tucnak/telebot)


### PR DESCRIPTION
Add link to the [PHP Telegram Bot](https://github.com/php-telegram-bot/core) project.